### PR TITLE
Fix crash when tuning candidates exceed small CV fold sizes

### DIFF
--- a/SMdRQA/RQA2.py
+++ b/SMdRQA/RQA2.py
@@ -2946,9 +2946,18 @@ class RQA2_ml:
                     pipe = make_pipeline(StandardScaler(), est)
                 else:
                     pipe = est
-                pipe.fit(X[train_idx], y[train_idx])
-                scores.append(accuracy_score(
-                    y[val_idx], pipe.predict(X[val_idx])))
+                # A candidate can be infeasible for small folds (e.g.
+                # knn n_neighbors > fold size); skip it like
+                # GridSearchCV's error_score instead of crashing.
+                try:
+                    pipe.fit(X[train_idx], y[train_idx])
+                    scores.append(accuracy_score(
+                        y[val_idx], pipe.predict(X[val_idx])))
+                except Exception:
+                    scores = []
+                    break
+            if not scores:
+                continue
             mean_score = np.mean(scores)
             if mean_score > best_score:
                 best_score = mean_score
@@ -2991,9 +3000,15 @@ class RQA2_ml:
                         pipe = make_pipeline(StandardScaler(), est)
                     else:
                         pipe = est
-                    pipe.fit(X_sub[train_idx], y[train_idx])
-                    scores.append(accuracy_score(
-                        y[val_idx], pipe.predict(X_sub[val_idx])))
+                    try:
+                        pipe.fit(X_sub[train_idx], y[train_idx])
+                        scores.append(accuracy_score(
+                            y[val_idx], pipe.predict(X_sub[val_idx])))
+                    except Exception:
+                        scores = []
+                        break
+                if not scores:
+                    continue
                 mean_score = np.mean(scores)
                 if mean_score > best_score:
                     best_score = mean_score
@@ -3025,9 +3040,15 @@ class RQA2_ml:
                         pipe = make_pipeline(StandardScaler(), est)
                     else:
                         pipe = est
-                    pipe.fit(X_sub[train_idx], y[train_idx])
-                    scores.append(accuracy_score(
-                        y[val_idx], pipe.predict(X_sub[val_idx])))
+                    try:
+                        pipe.fit(X_sub[train_idx], y[train_idx])
+                        scores.append(accuracy_score(
+                            y[val_idx], pipe.predict(X_sub[val_idx])))
+                    except Exception:
+                        scores = []
+                        break
+                if not scores:
+                    continue
                 mean_score = np.mean(scores)
                 if mean_score > best_score:
                     best_score = mean_score

--- a/SMdRQA/tests/test_RQA2_ml.py
+++ b/SMdRQA/tests/test_RQA2_ml.py
@@ -1195,3 +1195,31 @@ class TestSupervisedAll:
             X, y, models='all', cv=3, random_state=0)
         assert set(results_df['model']) == set(RQA2_ml._MODEL_REGISTRY)
         assert best_model.predict(X).shape == y.shape
+
+
+class TestTuningSmallFolds:
+
+    def test_tune_skips_infeasible_candidates(self):
+        # Regression: 20 samples -> inner 2-fold trains ~6 samples; knn
+        # grid candidates 7 and 9 exceed the fold size and used to raise
+        # "Expected n_neighbors <= n_samples_fit".
+        X, y = _two_class_data(n_per_class=10)
+        ml = RQA2_ml()
+        res = ml.nested_cv_benchmark(
+            X, y, model='knn', outer_iterations=3,
+            inner_splits=2, inner_iterations=1,
+            feature_selection=None, tune=True, random_state=0)
+        assert len(res['accuracy']) == 3
+        for params in res['best_params']:
+            assert params['n_neighbors'] in (3, 5)
+
+    def test_tiny_dataset_tune_and_selection_no_crash(self):
+        # 8 samples like the reported UI crash: every knn candidate is
+        # infeasible on some inner fold -> falls back to defaults.
+        X, y = _two_class_data(n_per_class=4)
+        ml = RQA2_ml()
+        res = ml.nested_cv_benchmark(
+            X, y, model='knn', outer_iterations=3,
+            inner_splits=2, inner_iterations=1,
+            feature_selection='forward', tune=True, random_state=0)
+        assert len(res['accuracy']) == 3


### PR DESCRIPTION
## Summary

On small datasets the inner CV folds can be smaller than some hyperparameter grid candidates, crashing the ML tab / `nested_cv_benchmark(tune=True)` with:

```
ValueError: Expected n_neighbors <= n_samples_fit, but n_neighbors = 7, n_samples_fit = 6, n_samples = 7
```

`_tune_hyperparams` now skips any candidate whose fit/predict fails on an inner fold (same idea as GridSearchCV's `error_score`) and falls back to model defaults when every candidate is infeasible. The exhaustive and forward feature-selection loops get the same guard, since a default model can also be infeasible on very small folds.

## Testing

Two regression tests reproduce the reported crash (20-sample and 8-sample dataset